### PR TITLE
📝  update docs to reflect minimum supported gRPC version

### DIFF
--- a/src/pages/instrumentation/java-agent.md
+++ b/src/pages/instrumentation/java-agent.md
@@ -23,7 +23,7 @@ List of supported frameworks with additional capabilities:
 |--------------------------------------------------------------------------------------------------------|-----------------|
 | [Apache HttpAsyncClient](https://hc.apache.org/index.html)                                             | 4.1+            |
 | [Apache HttpClient](https://hc.apache.org/index.html)                                                  | 4.0+            |
-| [gRPC](https://github.com/grpc/grpc-java)                                                              | 1.5+            |
+| [gRPC](https://github.com/grpc/grpc-java)                                                              | 1.6+            |
 | [JAX-RS Client](https://javaee.github.io/javaee-spec/javadocs/javax/ws/rs/client/package-summary.html) | 2.0+            |
 | [Micronaut](https://micronaut.io/)  (basic support via Netty)                                          | 1.0+            |
 | [Netty](https://github.com/netty/netty)                                                                | 4.0+            |


### PR DESCRIPTION
## Description
Recently, OTEL raised the minimum supported gRPC version: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/2948/files. We don't have users on gRPC 1.5, and it's quite old, so we don't anticipate getting any value out of supporting it. Instead, we can follow suit and drop support for 1.5. 

Java Agent PR: https://github.com/hypertrace/javaagent/pull/338